### PR TITLE
Add unit tests via CTest and fix one faulty test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+project(VMWithEditor LANGUAGES C VERSION 1.0)
+
+add_subdirectory(VMWithEditor)
+enable_testing()
+add_subdirectory(VMWithEditor/UnitTests/CommandLine_UnitTest/CommandLine_UnitTest)
+add_subdirectory(VMWithEditor/UnitTests/ControlConsole_UnitTest/ControlConsole_UnitTest)
+add_subdirectory(VMWithEditor/UnitTests/Editor_UnitTest/Editor_UnitTest)
+add_subdirectory(VMWithEditor/UnitTests/HRF_UnitTest/HRF_UnitTest)
+add_subdirectory(VMWithEditor/UnitTests/Parser_Unit_Test/Parser_Unit_Test)
+add_subdirectory(VMWithEditor/UnitTests/State_Machine_Unit_Test/State_Machine_Unit_Test)
+add_subdirectory(VMWithEditor/UnitTests/VirtualMachine_UnitTest/VirtualMachine_UnitTest)

--- a/VMWithEditor/UnitTests/CommandLine_UnitTest/CommandLine_UnitTest/CMakeLists.txt
+++ b/VMWithEditor/UnitTests/CommandLine_UnitTest/CommandLine_UnitTest/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.16.1)
-
-set(EXECUTABLE_NAME "CommandLine_UnitTest.exe")
-
-project(${EXECUTABLE_NAME} LANGUAGES C VERSION 1.0)
+set(EXECUTABLE_NAME "CommandLine_UnitTest")
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     set(GCC_WARN_COMPILE_FLAGS  " -Wall ")
@@ -25,4 +21,5 @@ target_include_directories(${EXECUTABLE_NAME} PUBLIC "${PROJECT_BINARY_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${VM_SRC_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${COMMON_TEST_DIR}")
 
-
+add_test(NAME "command-line-unit-test"
+         COMMAND "${EXECUTABLE_NAME}")

--- a/VMWithEditor/UnitTests/ControlConsole_UnitTest/ControlConsole_UnitTest/CMakeLists.txt
+++ b/VMWithEditor/UnitTests/ControlConsole_UnitTest/ControlConsole_UnitTest/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.16.1)
-
-set(EXECUTABLE_NAME "Control_Console_Unit_Test.exe")
-
-project(${EXECUTABLE_NAME} LANGUAGES C VERSION 1.0)
+set(EXECUTABLE_NAME "Control_Console_Unit_Test")
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     set(GCC_WARN_COMPILE_FLAGS  " -Wall ")
@@ -25,4 +21,6 @@ target_include_directories(${EXECUTABLE_NAME} PUBLIC "${PROJECT_BINARY_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${VM_SRC_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${COMMON_TEST_DIR}")
 
+add_test(NAME "control-console-unit-test"
+         COMMAND "${EXECUTABLE_NAME}")
 

--- a/VMWithEditor/UnitTests/Editor_UnitTest/Editor_UnitTest/CMakeLists.txt
+++ b/VMWithEditor/UnitTests/Editor_UnitTest/Editor_UnitTest/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.16.1)
-
-set(EXECUTABLE_NAME "Editor_Unit_Test.exe")
-
-project(${EXECUTABLE_NAME} LANGUAGES C VERSION 1.0)
+set(EXECUTABLE_NAME "Editor_Unit_Test")
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     set(GCC_WARN_COMPILE_FLAGS  " -Wall ")
@@ -25,4 +21,5 @@ target_include_directories(${EXECUTABLE_NAME} PUBLIC "${PROJECT_BINARY_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${VM_SRC_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${COMMON_TEST_DIR}")
 
-
+add_test(NAME "editor-unit-test"
+         COMMAND "${EXECUTABLE_NAME}")

--- a/VMWithEditor/UnitTests/Editor_UnitTest/Editor_UnitTest/Editor_UnitTest_Main.c
+++ b/VMWithEditor/UnitTests/Editor_UnitTest/Editor_UnitTest/Editor_UnitTest_Main.c
@@ -32,7 +32,7 @@ int main()
 	ERH_error_out_file = stderr;
 
 	if (!ERH_init_vm_error_reporting(NULL) ||
-		UTL_init_unit_tests("editor_unit_test_log.txt"))
+		!UTL_init_unit_tests("editor_unit_test_log.txt"))
 	{
 		return EXIT_FAILURE;
 	}

--- a/VMWithEditor/UnitTests/HRF_UnitTest/HRF_UnitTest/CMakeLists.txt
+++ b/VMWithEditor/UnitTests/HRF_UnitTest/HRF_UnitTest/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.16.1)
-
-set(EXECUTABLE_NAME "HRF_Unit_Test.exe")
-
-project(${EXECUTABLE_NAME} LANGUAGES C VERSION 1.0)
+set(EXECUTABLE_NAME "HRF_Unit_Test")
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     set(GCC_WARN_COMPILE_FLAGS  " -Wall ")
@@ -25,4 +21,5 @@ target_include_directories(${EXECUTABLE_NAME} PUBLIC "${PROJECT_BINARY_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${VM_SRC_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${COMMON_TEST_DIR}")
 
-
+add_test(NAME "HRF-unit-test"
+         COMMAND "${EXECUTABLE_NAME}")

--- a/VMWithEditor/UnitTests/Parser_Unit_Test/Parser_Unit_Test/CMakeLists.txt
+++ b/VMWithEditor/UnitTests/Parser_Unit_Test/Parser_Unit_Test/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.16.1)
-
-set(EXECUTABLE_NAME "Parser_Unit_Test.exe")
-
-project(${EXECUTABLE_NAME} LANGUAGES C VERSION 1.0)
+set(EXECUTABLE_NAME "Parser_Unit_Test")
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     set(GCC_WARN_COMPILE_FLAGS  " -Wall ")
@@ -27,6 +23,5 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE "${VM_SRC_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${COMMON_TEST_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${LEXICAL_TEST_DIR}")
 
-
-
-
+add_test(NAME "parser-unit-test"
+         COMMAND "${EXECUTABLE_NAME}")

--- a/VMWithEditor/UnitTests/State_Machine_Unit_Test/State_Machine_Unit_Test/CMakeLists.txt
+++ b/VMWithEditor/UnitTests/State_Machine_Unit_Test/State_Machine_Unit_Test/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.16.1)
-
-set(EXECUTABLE_NAME "Lexical_Analyzer_Unit_Test.exe")
-
-project(${EXECUTABLE_NAME} LANGUAGES C VERSION 1.0)
+set(EXECUTABLE_NAME "Lexical_Analyzer_Unit_Test")
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     set(GCC_WARN_COMPILE_FLAGS  " -Wall ")
@@ -25,4 +21,6 @@ target_include_directories(${EXECUTABLE_NAME} PUBLIC "${PROJECT_BINARY_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${VM_SRC_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${COMMON_TEST_DIR}")
 
+add_test(NAME "lexical-analyzer-unit-test"
+         COMMAND "${EXECUTABLE_NAME}")
 

--- a/VMWithEditor/UnitTests/VirtualMachine_UnitTest/VirtualMachine_UnitTest/CMakeLists.txt
+++ b/VMWithEditor/UnitTests/VirtualMachine_UnitTest/VirtualMachine_UnitTest/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.16.1)
-
 set(EXECUTABLE_NAME "VirtualMachine_UnitTest.exe")
-
-project(${EXECUTABLE_NAME} LANGUAGES C VERSION 1.0)
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     set(GCC_WARN_COMPILE_FLAGS  " -Wall ")
@@ -25,4 +21,6 @@ target_include_directories(${EXECUTABLE_NAME} PUBLIC "${PROJECT_BINARY_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${VM_SRC_DIR}")
 target_include_directories(${EXECUTABLE_NAME} PRIVATE "${COMMON_TEST_DIR}")
 
+add_test(NAME "virtual-machine-unit-test"
+         COMMAND "${EXECUTABLE_NAME}")
 


### PR DESCRIPTION
Added CTest capability for all unit tests and fixed one of them.  With this, you can issue the `cmake` command and point to the base directory and the program and all tests will be created.  They can then be run by executing `ctest`.